### PR TITLE
Inject mock objects with Pheasant::mock()

### DIFF
--- a/lib/Pheasant.php
+++ b/lib/Pheasant.php
@@ -10,6 +10,7 @@ class Pheasant
 	private $_schema;
 	private $_finders=array();
 	private $_mappers=array();
+	private $_mockloader;
 
 	private static $_instance;
 
@@ -134,6 +135,33 @@ class Pheasant
 			throw new Exception("No finder registered for $class");
 
 		return $this->_finders[$class];
+	}
+
+	/**
+	 * Register a callback to use to return a class whenever the 
+	 * class is instantiated. This is done be prepending a class
+	 * loader that dynamically the class, so it won't work if the
+	 * class is already loaded.
+	 * @chainable
+	 */
+	public function mock($class, $callback)
+	{
+		$this->mockloader()->mock($class, $callback);
+		return $this;
+	}
+
+	/**
+	 * Returns the internal MockLoader instance
+	 */
+	public function mockLoader()
+	{
+		if(!isset($this->_mockloader))
+		{
+			$this->_mockloader = new \Pheasant\MockLoader();
+			$this->_mockloader->register();
+		}
+
+		return $this->_mockloader;
 	}
 
 	// ----------------------------------------

--- a/lib/Pheasant/MockLoader.php
+++ b/lib/Pheasant/MockLoader.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pheasant;
+
+class MockLoader
+{
+	private $_mocks=array();
+
+	public function load($className)
+	{
+		if(!isset($this->_mocks[$className]))
+			return false;
+
+		$hierarchy = explode('\\', $className);
+		$className = array_pop($hierarchy);
+		$namespace = implode('\\', $hierarchy);
+
+		// unfortunately class_alias doesn't work
+		eval(sprintf(
+			"namespace %s;\n\nclass %s extends \Pheasant\MockProxy {}",
+			$namespace, 
+			$className
+		));
+
+		return true;
+	}
+
+	public function mock($className, $callback)
+	{
+		$this->_mocks[$className] = $callback;
+		return $this;
+	}
+
+	public function mockFor($className)
+	{
+		return call_user_func($this->_mocks[get_class($className)]);
+	}
+
+	public function register()
+	{
+		spl_autoload_register(array($this,'load'), true, true);
+		return $this;
+	}
+}

--- a/lib/Pheasant/MockProxy.php
+++ b/lib/Pheasant/MockProxy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pheasant;
+
+class MockProxy
+{
+	private $_delegate;
+
+	private function _mockDelegate()
+	{
+		if(!isset($this->_delegate))
+			$this->_delegate = \Pheasant::instance()->mockLoader()->mockFor($this);
+
+		return $this->_delegate;
+	}
+
+	public function __call($method, $params)
+	{
+		return call_user_func_array(array($this->_mockDelegate(), $method), $params);
+	}
+
+	public function __get($prop)
+	{
+		return $this->_mockDelegate()->$prop;
+	}
+
+	public function __set($prop, $value)
+	{
+		$this->_mockDelegate()->$prop = $value;
+	}
+}
+

--- a/tests/mocks.php
+++ b/tests/mocks.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pheasant\Tests\Mocks;
+
+use \Pheasant;
+use \Pheasant\DomainObject;
+use \Pheasant\Types;
+
+require_once(__DIR__.'/../vendor/simpletest/autorun.php');
+require_once(__DIR__.'/base.php');
+
+\Mock::generate('\Pheasant\DomainObject','MockDomainObject');
+
+class MockTestCase extends \Pheasant\Tests\MysqlTestCase
+{
+	public function testCreatingAMock()
+	{
+		Pheasant::instance()->mock('Pheasant\Tests\Mocks\NotCreatedYet', function() {
+			return new \MockDomainObject();
+		});
+
+		$mock = new NotCreatedYet();
+		$this->assertIsA($mock, 'Pheasant\MockProxy');
+
+		$mock->setReturnValue('toArray', array('llamas'=>true));
+		$this->assertEqual($mock->toArray(), array('llamas'=>true));
+
+		$mock2 = new NotCreatedYet();
+		$this->assertFalse($mock === $mock2);
+	}
+}
+
+


### PR DESCRIPTION
Pheasant domain objects are created by constructing them, so injecting mocks requires some magic with classloaders. Provided the class isn't already loaded, `Pheasant::mock()` allows for the a closure to be used to instantiate objects.

``` php
<?php

use \Mockery as M;

Pheasant::mock('\Animals\Llama', function() {
   $mock = M::mock('\Animals\Llama');
   $mock->shouldReceive('shear')->with('lightly')->once();
   $mock->shouldReceive('save')->once();
   return $mock;
});

$object = new \Animals\Llama();
$object->shear('lightly');
$object->save();

M::close();
```
