### PR TITLE
Adds test and fix for when an array is passed to Criteria

### DIFF
--- a/lib/Pheasant/Query/Criteria.php
+++ b/lib/Pheasant/Query/Criteria.php
@@ -25,8 +25,10 @@ class Criteria
 		}
 		else if(is_array($where))
 		{
+			$boundWhere = array();
 			foreach($where as $key=>$val)
-				$this->and($this->bind($key.'=?', array($val)));
+				$boundWhere[] = $this->bind($key.'=?', array($val));
+			$this->_sql = $this->_join('AND', $boundWhere);
 		}
 		else
 		{

--- a/tests/Pheasant/Tests/CriteriaTest.php
+++ b/tests/Pheasant/Tests/CriteriaTest.php
@@ -17,6 +17,9 @@ class CriteriaTest extends \Pheasant\Tests\MysqlTestCase
 
 		$criteria = new Criteria(55);
 		$this->assertEquals("55", $criteria->toSql());
+
+		$criteria = new Criteria(array('key1' => 'val1', 'key2' => 'val2'));
+		$this->assertEquals("(key1='val1' AND key2='val2')", $criteria->toSql());
 	}
 
 	public function testNestedCriteria()


### PR DESCRIPTION
When the Criteria is instantiated with an array as an argument, the code suggests that the items in the array should be used as AND conditions.

However, the way the `->and()` and `->or()` methods have been implemented, the whole criteria sql is overwritten when one of these are called.

I'm not sure of the intended behaviour, so this patch fixes the issue in the constructor rather than modifying the `->and()` and `->or()` methods
