### PR TITLE
Chaining and() and or() in Criteria now works

### DIFF
--- a/lib/Pheasant/Query/TableCriteria.php
+++ b/lib/Pheasant/Query/TableCriteria.php
@@ -9,10 +9,10 @@ class TableCriteria extends Criteria
 {
 	private $_table;
 
-  public function __construct($table, $where, $params=array())
+	public function __construct($table, $where, $params=array())
 	{
 		parent::__construct($where, $params);
-    $this->_table = $table;
+		$this->_table = $table;
 	}
 
 	public function update($data)
@@ -38,7 +38,7 @@ class TableCriteria extends Criteria
 	public function count()
 	{
 		return $this->_table->query()->select('COUNT(*)')->where($this)->scalar();
-	}	
+	}
 }
 
 

--- a/tests/Pheasant/Tests/CriteriaTest.php
+++ b/tests/Pheasant/Tests/CriteriaTest.php
@@ -9,28 +9,44 @@ class CriteriaTest extends \Pheasant\Tests\MysqlTestCase
 {
 	public function testBasicCriteria()
 	{
-		$criteria = new Criteria('?', array('test'));
-		$this->assertEquals("'test'", $criteria->toSql());
+		$c = new Criteria('column = ?', 'test');
+		$this->assertEquals("(column = 'test')", $c->toSql());
 
-		$criteria = new Criteria('column > ?', array(55));
-		$this->assertEquals("column > '55'", $criteria->toSql());
-
-		$criteria = new Criteria(55);
-		$this->assertEquals("55", $criteria->toSql());
-
-		$criteria = new Criteria(array('key1' => 'val1', 'key2' => 'val2'));
-		$this->assertEquals("(`key1`='val1' AND `key2`='val2')", $criteria->toSql());
+		$c = new Criteria('column > ?', 55);
+		$this->assertEquals("(column > '55')", $c->toSql());
 	}
 
-	public function testNestedCriteria()
+	public function testCriteriaFromArray()
 	{
-		$cr = new Criteria();
-		$cr->or(
-			$cr->and('a > 1', $cr->bind('b != ?', array('blargh'))),
+		$c = new Criteria(array('key1' => 'val1', 'key2' => 'val2'));
+		$this->assertEquals("(`key1`='val1' AND `key2`='val2')", $c->toSql());
+	}
+
+	public function testCriteriaConcatWithAnd()
+	{
+		$c = new Criteria('column > ?', 55);
+		$c->and('column <> 0')->and('column < 100');
+
+		$this->assertEquals("(((column > '55') AND column <> 0) AND column < 100)", $c->toSql());
+	}
+
+	public function testAddingToCriteriaWithOr()
+	{
+		$c = new Criteria('column > ?', 55);
+		$c->or('column <> 0', 'column < 100')->and('column < 30');
+
+		$this->assertEquals("(((column > '55') OR column <> 0 OR column < 100) AND column < 30)", $c->toSql());
+	}
+
+	public function testCriteriaConcat()
+	{
+		$c = new Criteria();
+		$c = $c->or(
+			Criteria::concatAnd('a > 1', $c->bind('b != ?', 'blargh')),
 			'x = 1'
 			);
 
 		$this->assertEquals("((a > 1 AND b != 'blargh') OR x = 1)",
-			$cr->toSql());
+			$c->toSql());
 	}
 }

--- a/tests/Pheasant/Tests/RelationshipTest.php
+++ b/tests/Pheasant/Tests/RelationshipTest.php
@@ -80,4 +80,39 @@ class RelationshipTestCase extends \Pheasant\Tests\MysqlTestCase
 		$this->assertEquals($identity->identityid, 1);
 		$this->assertEquals($hero->identityid, 1);
 	}
+
+	public function testFilteringCollectionsReturnedByRelationships()
+	{
+		$spiderman = $this->_createHero('Spider Man', 'Peter Parker', array(
+			'Super-human Strength', 'Spider Senses'
+		));
+		$superman = $this->_createHero('Super Man', 'Clark Kent', array(
+			'Super-human Strength', 'Invulnerability'
+		));
+		$batman = $this->_createHero('Batman', 'Bruce Wayne', array(
+			'Richness', 'Super-human Intellect'
+		));
+
+		$this->assertCount(2, $spiderman->Powers);
+		$this->assertCount(1, $spiderman->Powers->filter('description LIKE ?', 'Super-human%')->toArray());
+	}
+
+	private function _createHero($alias, $identity, $powers=array())
+	{
+		$hero = new Hero(array('alias'=>$alias));
+		$hero->save();
+
+		$identity = new SecretIdentity(array('realname'=>$identity));
+		$hero->SecretIdentity = $identity;
+		$identity->save();
+
+		foreach($powers as $power)
+		{
+				$power = new Power(array('description'=>$power));
+				$hero->Powers []= $power;
+				$power->save();
+		}
+
+		return $hero;
+	}
 }

--- a/tests/Pheasant/Tests/TableCriteriaTest.php
+++ b/tests/Pheasant/Tests/TableCriteriaTest.php
@@ -26,22 +26,22 @@ class TableCriteriaTest extends \Pheasant\Tests\MysqlTestCase
 	{
 		$criteria = $this->table->where('firstname=?', 'Llama');
 
-		$this->assertEquals((string) $criteria, "firstname='Llama'");
+		$this->assertEquals("(firstname='Llama')", (string) $criteria);
 		$this->assertEquals($criteria->count(), 1);
 	}
 
 	public function testWhereWithArray()
 	{
 		$criteria = $this->table->where(array('firstname'=>'Llama'));
-		$this->assertEquals($criteria->toSql(), "(`firstname`='Llama')");
-		$this->assertEquals($criteria->count(), 1);
+		$this->assertEquals("(`firstname`='Llama')", $criteria->toSql());
+		$this->assertEquals(1, $criteria->count(), 1);
 	}
 
 	public function testWhereWithCriteria()
 	{
 		$criteria = $this->table->where(new \Pheasant\Query\Criteria(array('firstname'=>'Llama')));
-		$this->assertEquals($criteria->toSql(), "(`firstname`='Llama')");
-		$this->assertEquals($criteria->count(), 1);
+		$this->assertEquals("(`firstname`='Llama')", $criteria->toSql());
+		$this->assertEquals(1, $criteria->count());
 	}
 
 	public function testUpdateByCriteria()


### PR DESCRIPTION
This is a response to bug #27.

As originally designed, the and() and or() methods on a Criteria object didn't chain:

``` php
<?php

$c = new Criteria();
$c->and('llamas = true')->and('quantity > 1');
// results in (quantity > 1)
```

Obviously this wasn't expected, or the desired behavior, but it came about to support complex chaining like:

``` php
<?php

$c = new Criteria();
$c->or(
   $c->and('llamas = true', 'quantity > 1'),
   'alpaca = true'
);
// results in (llamas = true AND quantity > 1) OR alpaca = true
```

The more I've thought about that syntax, the crazier it is. The above is now accomplished like this:

``` php
<?php

$c = new Criteria();
$c->or(
   Criteria::concatAnd('llamas = true', 'quantity > 1'),
   'alpaca = true'
);
// results in (llamas = true AND quantity > 1) OR alpaca = true
```

Chaining now works as you'd expect it to:

``` php
<?php

$c = new Criteria();
$c->and('llamas = true')->and('quantity > 1');
// results in ((llamas = true) AND quantity > 1)
```
