### PR TITLE
Implement magic method __isset to be compatible with Twig

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -376,4 +376,12 @@ class DomainObject
 	{
 		return call_user_func($this->schema()->setter($key), $this, $value);
 	}
+
+	/**
+	* Magic method, delegates to the schema
+	*/
+	public function __isset($key)
+	{
+		return ($this->schema()->hasAttribute($key) && $this->$key);
+	}
 }

--- a/lib/Pheasant/Schema.php
+++ b/lib/Pheasant/Schema.php
@@ -152,4 +152,21 @@ class Schema
 
 		throw new Exception("No setter available for $attr");
 	}
+
+	/**
+	* Check if attribute is available on a domain object
+	*/
+	public function hasAttribute($attr)
+	{
+		if(isset($this->_setters[$attr]))
+			return true;
+
+		else if(isset($this->_props[$attr]))
+			return true;
+
+		else if(isset($this->_rels[$attr]))
+			return true;
+
+		return false;
+	}
 }

--- a/tests/Pheasant/Tests/DomainObjectTest.php
+++ b/tests/Pheasant/Tests/DomainObjectTest.php
@@ -35,6 +35,16 @@ class DomainObjectTest extends \Pheasant\Tests\MysqlTestCase
 		$this->assertFalse($llama->equals($frog));
 	}
 
+	public function testPropertyIsset()
+	{
+		$animal = new Animal(array('name'=>'bob'));
+
+		$this->assertTrue(isset($animal->type));
+		$this->assertTrue(isset($animal->name));
+
+		$this->assertFalse(isset($animal->unknown));
+	}
+
 	/**
 	 * @expectedException Pheasant\Exception
 	 */


### PR DESCRIPTION
This is needed to be able to pass a domain object directly into twig so we can use animal.breed without writing custom getters.
