### PR TITLE
Add Id type

### DIFF
--- a/lib/Pheasant/Types/Id.php
+++ b/lib/Pheasant/Types/Id.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Pheasant\Types;
+
+class Id extends Integer
+{
+	const ID_LENGTH = 11;
+
+	public function __construct($options=null)
+	{
+		parent::__construct(self::ID_LENGTH, $options);
+	}
+}

--- a/lib/Pheasant/Types/Sequence.php
+++ b/lib/Pheasant/Types/Sequence.php
@@ -2,13 +2,13 @@
 
 namespace Pheasant\Types;
 
-class Sequence extends Integer
+class Sequence extends Id
 {
 	public $sequence;
 
 	public function __construct($sequence=null, $params=null)
 	{
-		parent::__construct(11, sprintf("sequence=%s primary required %s",
+		parent::__construct(sprintf("sequence=%s primary required %s",
 			is_null($sequence) ? 'null' : $sequence, $params));
 
 		$this->sequence = $sequence;

--- a/tests/Pheasant/Tests/TypesTest.php
+++ b/tests/Pheasant/Tests/TypesTest.php
@@ -7,6 +7,17 @@ use \Pheasant\Database\Mysqli;
 
 class TypesTest extends \Pheasant\Tests\MysqlTestCase
 {
+	public function testId()
+	{
+		$type = new Types\Id();
+		$this->assertEquals($type->type, Types\Integer::TYPE);
+		$this->assertEquals($type->length, 11);
+
+		$map = new Mysqli\TypeMap(array('test'=>$type));
+		$this->assertEquals($map->columnDef('test'),
+			'`test` int(11)');
+	}
+
 	public function testInteger()
 	{
 		$type = new Types\Integer(10);


### PR DESCRIPTION
Currently primary keys using `Sequence` can be mapped incorrectly from another domain object eg. `foreignid => new Types\Integer(5)` when `Sequence` is actually `Integer(11)`.

This adds an `Id` type so that domain objects can define foreign keys using `new Types\Id()` to consistently map to an existing `Sequence` property.

eg. 

``` php
public function properties()
{
  return array(
    'id' => new Sequence(),
    'userid' => new Id()
  );
}
```

Thoughts @lox?
