### PR TITLE
Close connection in test cases

### DIFF
--- a/tests/Pheasant/Tests/MysqlTestCase.php
+++ b/tests/Pheasant/Tests/MysqlTestCase.php
@@ -19,6 +19,11 @@ class MysqlTestCase extends \PHPUnit_Framework_TestCase
 			;
 	}
 
+	public function tearDown()
+	{
+		$this->pheasant->connection()->close();
+	}
+
 	// Helper to return a connection
 	public function connection()
 	{


### PR DESCRIPTION
This should allow phpunit tests to run cleanly without running out of connections.
