### PR TITLE
Transaction uses Pheasant singleton connection by default

### DIFF
--- a/lib/Pheasant/Database/Mysqli/Transaction.php
+++ b/lib/Pheasant/Database/Mysqli/Transaction.php
@@ -14,9 +14,9 @@ class Transaction
 	/**
 	 * Constructor
 	 */
-	public function __construct($connection)
+	public function __construct($connection=null)
 	{
-		$this->_connection = $connection;
+		$this->_connection = $connection ?: \Pheasant::instance()->connection();
 	}
 
 	public function execute()


### PR DESCRIPTION
A minor change to make using the `Transaction` class slightly easier.
