### PR TITLE
System-wide events, and event bubbling from object->schema->system

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -212,7 +212,7 @@ class DomainObject
     public function events($events=array())
     {
         if (!isset($this->_events)) {
-            $this->_events = clone $this->schema()->events();
+            $this->_events = new Events(array(), self::schema()->events());
             $this->_registerDefaultEventHandlers();
         }
 

--- a/lib/Pheasant/Events.php
+++ b/lib/Pheasant/Events.php
@@ -3,18 +3,23 @@
 namespace Pheasant;
 
 /**
- * Domain objects have events triggered on them via Events.
+ * A collection of event handlers that have events fired to them. Events
+ * also bubble upstream.
  */
 class Events
 {
-    private $_handlers=array();
+    private
+        $_handlers=array(),
+        $_upstream
+        ;
 
     /**
      * Construct
      */
-    public function __construct($handlers=array())
+    public function __construct($handlers=array(), $upstream=null)
     {
         $this->_handlers = array();
+        $this->_upstream = $upstream;
 
         foreach ($handlers as $event=>$handler) {
             $this->_handlers[$event] = is_array($handler)
@@ -55,6 +60,9 @@ class Events
             foreach($callbacks as $callback)
                 call_user_func($callback, $e, $object);
         }
+
+        if(isset($this->_upstream))
+            $this->_upstream->trigger($event, $object);
 
         return $this;
     }

--- a/lib/Pheasant/Schema.php
+++ b/lib/Pheasant/Schema.php
@@ -30,7 +30,7 @@ class Schema
         $this->_rels = $params['relationships'];
         $this->_getters = $params['getters'];
         $this->_setters = $params['setters'];
-        $this->_events = new Events($params['events']);
+        $this->_events = $params['events'];
     }
 
     /**
@@ -105,7 +105,7 @@ class Schema
     }
 
     /**
-     * Return the internal {@link Events} object
+     * Return the schema-wide {@link Events} object
      * @return Events
      */
     public function events()

--- a/lib/Pheasant/SchemaBuilder.php
+++ b/lib/Pheasant/SchemaBuilder.php
@@ -8,12 +8,19 @@ namespace Pheasant;
 class SchemaBuilder
 {
     private
+        $_pheasant,
         $_properties=array(),
         $_relationships=array(),
         $_events=array(),
         $_getters=array(),
         $_setters=array()
         ;
+
+    public function __construct($pheasant)
+    {
+        $this->_pheasant = $pheasant;
+        $this->_events = new Events(array(), $pheasant->events());
+    }
 
     /**
      * Sets the schema properties
@@ -46,7 +53,7 @@ class SchemaBuilder
     public function events($map)
     {
         foreach($map as $name=>$callback)
-            $this->_events[$name] = $callback;
+            $this->_events->register($name, $callback);
 
         return $this;
     }

--- a/tests/Pheasant/Tests/EventsTest.php
+++ b/tests/Pheasant/Tests/EventsTest.php
@@ -115,4 +115,23 @@ class EventsTestCase extends \Pheasant\Tests\MysqlTestCase
 
         $this->assertEquals($do->events, array('beforeSave','afterSave'));
     }
+
+    public function testSystemWideInitializeEvent()
+    {
+        $events = array();
+
+        $this->pheasant->events()->register('afterInitialize', function($e, $schema) use(&$events) {
+            $events []= func_get_args();
+        });
+
+        $this->initialize('Pheasant\Tests\Examples\EventTestObject', function($builder) {
+            $builder->properties(array(
+                'test' => new Types\String()
+                ));
+        });
+
+        $this->assertCount(1, $events);
+        $this->assertEquals('Pheasant\Tests\Examples\EventTestObject', $events[0][1]->className());
+        $this->assertEquals('afterInitialize', $events[0][0]);
+     }
 }


### PR DESCRIPTION
Added an new event: `beforeInitialize(schemaBuilder)` and `afterInitialize(schema)`

Now there are three points for event registration:
- System-wide:

``` php
Pheasant::instance()->events()->register('afterInitialize', function($event, $schema) {
   // do some setup for the object
});
```
- Schema-specific

``` php
Llamas::events()->register('beforeSave', function($event, $object) {
   // do something before saving all Llama objects
});
```
- Instance-specific

``` php
$llama = new Llama();
$llama->events()->register('beforeSave', function($event, $object) {
   // do some setup for the object
});
```

The interesting thing about this system is it bubbles. Events are fired at the most granular possible level and they bubble upwards, eventually ending up at the system event handler.
