### PR TITLE
Implement ArrayAccess in DomainObject

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -499,12 +499,12 @@ class DomainObject implements \ArrayAccess
 
     public function offsetGet($offset)
     {
-        return $this->get($offset);
+        return $this->__get($offset);
     }
 
     public function offsetSet($offset, $value)
     {
-        return $this->set($offset, $value);
+        return $this->__set($offset, $value);
     }
 
     public function offsetUnset($offset)

--- a/tests/Pheasant/Tests/DomainObjectTest.php
+++ b/tests/Pheasant/Tests/DomainObjectTest.php
@@ -161,14 +161,14 @@ class DomainObjectTest extends \Pheasant\Tests\MysqlTestCase
     public function testArrayAccess()
     {
         $llama = Animal::create(array('name' => 'Frank'));
-        $this->assertTrue($llama->offsetExists('name'));
-        $this->assertEquals("Frank", $llama->offsetGet('name'));
+        $this->assertTrue(isset($llama['name']));
+        $this->assertEquals("Frank", $llama['name']);
 
         $llama = Animal::create(array('name' => null));
-        $this->assertTrue($llama->offsetExists('name'));
-        $this->assertNull($llama->offsetGet('name'));
+        $this->assertTrue(isset($llama['name']));
+        $this->assertNull($llama['name']);
 
-        $llama->offsetSet('name', 'Joe');
-        $this->assertEquals("Joe", $llama->offsetGet('name'));
+        $llama['name'] = 'Joe';
+        $this->assertEquals("Joe", $llama['name']);
     }
 }


### PR DESCRIPTION
## What this is

This pull request adds support for the `ArrayAccess` interface in DomainObject
## Why

Some libraries (e.g. `Twig`) rely on standard interfaces/functions to check if a property exists. However, Pheasant doesn't support any (?) standard method to check the existence of null properties.
- `isset` will call `__isset`, which correctly return false when the value is `null`
- `property_exists` doesn't work with magic setters and getters
- `array_key_exists` doesn't work, because it's not an array and it's not a real property

Pheasant supports `has($name)`, but it's not a standard and libraries are unlikely to check it.
## Why ArrayAccess

Implementing ArrayAccess means that 

`isset($object[$propertyName])` 

will return `true` for null values, and will provide a standard way of checking if a property exists (independently of the value).
