### PR TITLE
Make __isset return true for false values

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -486,6 +486,6 @@ class DomainObject
     */
     public function __isset($key)
     {
-        return ($this->schema()->hasAttribute($key) && $this->$key);
+        return ($this->schema()->hasAttribute($key) && $this->$key !== null);
     }
 }

--- a/tests/Pheasant/Tests/DomainObjectTest.php
+++ b/tests/Pheasant/Tests/DomainObjectTest.php
@@ -157,4 +157,11 @@ class DomainObjectTest extends \Pheasant\Tests\MysqlTestCase
 
         $this->assertEquals('Frank', $llama->name);
     }
+
+    public function testIssetWithBooleanValues()
+    {
+        $llama = Animal::create(array('name' => false));
+
+        $this->assertTrue(isset($llama->name));
+    }
 }


### PR DESCRIPTION
## What this is

`__isset` should only return `false` if that property is not set or if it's `null`.

http://php.net/manual/en/function.isset.php
