### PR TITLE
Make DomainObject __isset work for false values

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -486,6 +486,6 @@ class DomainObject
     */
     public function __isset($key)
     {
-        return ($this->schema()->hasAttribute($key) && $this->$key);
+        return ($this->schema()->hasAttribute($key) && !is_null($this->$key));
     }
 }


### PR DESCRIPTION
This updates `DomainObject->__isset()` to check for null values explicitly (rather than checking general truthiness)

I found that twig templates use `isset` to check if a property exists. It was failing because `isset` was returning false for boolean false values.
