### PR TITLE
Fix broken support for chained orderBy(). Fixes issue #65

### DIFF
--- a/lib/Pheasant/Query/Query.php
+++ b/lib/Pheasant/Query/Query.php
@@ -16,7 +16,7 @@ class Query implements \IteratorAggregate, \Countable
     private $_limit=null;
     private $_where;
     private $_group;
-    private $_order;
+    private $_order=array();
 
     // resultset
     private $_connection;
@@ -138,7 +138,7 @@ class Query implements \IteratorAggregate, \Countable
     public function orderBy($sql, $params=array())
     {
         $binder = new Binder();
-        $this->_order = $binder->magicBind($sql, (array) $params);
+        $this->_order[] = $binder->magicBind($sql, (array) $params);
 
         return $this;
     }

--- a/tests/Pheasant/Tests/QueryTest.php
+++ b/tests/Pheasant/Tests/QueryTest.php
@@ -108,5 +108,17 @@ class QueryTest extends \Pheasant\Tests\MysqlTestCase
         $this->assertEquals(
             'SELECT userid FROM user ORDER BY userid',
             $query->toSql());
+
+        $query = new Query();
+        $query
+            ->select('foo')
+            ->from('bar')
+            ->orderBy('baz')
+            ->orderBy('moo')
+            ;
+
+        $this->assertEquals(
+            'SELECT foo FROM bar ORDER BY baz, moo',
+            $query->toSql());
     }
 }


### PR DESCRIPTION
Also added a new testcase which test the chaining of orderBy() calls.
