### PR TITLE
Async query support

### DIFF
--- a/lib/Pheasant/Collection.php
+++ b/lib/Pheasant/Collection.php
@@ -4,6 +4,7 @@ namespace Pheasant;
 
 use \Pheasant;
 use \Pheasant\Query\QueryIterator;
+use \Pheasant\Query\AsyncQueryIterator;
 
 class Collection implements \IteratorAggregate, \Countable, \ArrayAccess
 {
@@ -27,6 +28,21 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess
         $this->_iterator = new QueryIterator($query, function($row) use ($schema) {
             return $schema->hydrate($row);
         });
+    }
+
+    public function async($connection='default')
+    {
+        $connection = is_object($connection)
+            ? $connection
+            : Pheasant::instance()->connection($connection);
+
+        $this->_query->setConnection($connection);
+        $schema = $this->_schema;
+        $this->_iterator = new AsyncQueryIterator($this->_query, function($row) use ($schema) {
+            return $schema->hydrate($row);
+        });
+        $this->_readonly = true;
+        return $this;
     }
 
     /**

--- a/lib/Pheasant/Database/Mysqli/AsyncResultSet.php
+++ b/lib/Pheasant/Database/Mysqli/AsyncResultSet.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Pheasant\Database\Mysqli;
+
+/**
+ * Encapsulates the result of executing a statement
+ */
+class AsyncResultSet implements \IteratorAggregate, \ArrayAccess, \Countable
+{
+    private $_link, $_result, $_affected, $_hydrator, $_fields;
+
+    /**
+     * Constructor
+     * @param $link MySQLi
+     */
+    public function __construct($link)
+    {
+        $this->_link = $link;
+    }
+
+    public function _result()
+    {
+        if (!isset($this->_result)) {
+            $this->_result = $this->_link->reap_async_query();
+            $this->_affected = $this->_link->affected_rows;
+
+        }
+
+        return $this->_result;
+    }
+
+    public function _affected()
+    {
+        $this->_result();
+        return $this->_affected;
+    }
+
+    public function setHydrator($callback)
+    {
+        $this->_hydrator = $callback;
+
+        return $this;
+    }
+
+    /* (non-phpdoc)
+     * @see IteratorAggregate::getIterator()
+     */
+    public function getIterator()
+    {
+        if(	$this->_result() === false)
+
+            return new \EmptyIterator(array());;
+
+        if (!isset($this->_iterator)) {
+            $this->_iterator = new ResultIterator($this->_result());
+            $this->_iterator->setHydrator($this->_hydrator);
+        }
+
+        return $this->_iterator;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return iterator_to_array($this->getIterator());
+    }
+
+    /**
+     * Returns the next available row as an associative array.
+     * @return array or NULL on EOF
+     */
+    public function row()
+    {
+        $iterator = $this->getIterator();
+
+        if(!$iterator->current())
+            $iterator->next();
+
+        $value = $iterator->current();
+        $iterator->next();
+
+        return $value;
+    }
+
+    /**
+     * Returns the nth column from the current row.
+     * @return scalar or NULL on EOF
+     */
+    public function scalar($idx=0)
+    {
+        $row = $this->row();
+
+        if(is_null($row))
+
+            return NULL;
+
+        $values = is_numeric($idx) ? array_values($row) : $row;
+
+        return $values[$idx];
+    }
+
+    /**
+     * Fetches an iterator that only returns a particular column, defaults to the
+     * first
+     * @return Iterator
+     */
+    public function column($column=null)
+    {
+        return new ColumnIterator($this->getIterator(), $column);
+    }
+
+    /**
+     * Seeks to a particular row offset
+     * @chainable
+     */
+    public function seek($offset)
+    {
+        $this->getIterator()->seek($offset);
+
+        return $this;
+    }
+
+    /**
+     * The number of rows that the statement affected
+     * @return int
+     */
+    public function affectedRows()
+    {
+        return $this->_affected();
+    }
+
+    /**
+        * The fields returned in the result set as an array of fields
+        * @return Fields object
+      */
+    public function fields()
+    {
+        if(!isset($this->_fields))
+            $this->_fields = new Fields($this->_result());
+
+        return $this->_fields;
+    }
+
+    /**
+     * The number of rows in the result set, or the number of affected rows
+     */
+    public function count()
+    {
+        return $this->_affected();
+    }
+
+    /**
+     * The last auto_increment value generated in the statement
+     */
+    public function lastInsertId()
+    {
+        return $this->_link->insert_id;
+    }
+
+    // ----------------------------------
+    // array access
+
+    public function offsetGet($offset)
+    {
+        $this->getIterator()->seek($offset);
+
+        return $this->getIterator()->current();
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \BadMethodCallException('ResultSets are read-only');
+    }
+
+    public function offsetExists($offset)
+    {
+        $this->getIterator()->seek($offset);
+
+        return $this->getIterator()->valid();
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \BadMethodCallException('ResultSets are read-only');
+    }
+}

--- a/lib/Pheasant/Database/Mysqli/Connection.php
+++ b/lib/Pheasant/Database/Mysqli/Connection.php
@@ -157,6 +157,36 @@ class Connection
         });
     }
 
+    public function asyncExecute($sql, $params=array())
+    {
+        if(!is_array($params))
+            $params = array_slice(func_get_args(),1);
+
+        $mysqli = $this->_mysqli();
+        $sql = count($params) ? $this->binder()->bind($sql, $params) : $sql;
+
+        // delegate execution to the filter chain
+        return $this->_filter->execute($sql, function($sql) use ($mysqli) {
+
+            \Pheasant\Database\Mysqli\Connection::$counter++;
+
+            $timer = microtime(true);
+            $r = $mysqli->query($sql, MYSQLI_ASYNC);
+
+            \Pheasant\Database\Mysqli\Connection::$timer += microtime(true)-$timer;
+
+            if (\Pheasant\Database\Mysqli\Connection::$debug) {
+                printf("<pre>Pheasant executed <code>%s</code> on thread #%d in %.2fms, returned %d rows</pre>\n\n",
+                    $sql, $mysqli->thread_id, (microtime(true)-$timer)*1000, is_object($r) ? $r->num_rows : 0);
+            }
+
+            if($mysqli->error)
+                throw new Exception($mysqli->error, $mysqli->errno);
+
+            return new AsyncResultSet($mysqli);
+        });
+    }
+
     /**
      * @return Transaction
      */

--- a/lib/Pheasant/Query/AsyncQueryIterator.php
+++ b/lib/Pheasant/Query/AsyncQueryIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Pheasant\Query;
+use \Pheasant\Pheasant;
+use \Pheasant\Query\QueryIterator;
+
+/**
+ * An iterator that lazily executes a query, hydrating as it goes
+ */
+class AsyncQueryIterator extends QueryIterator
+{
+    /**
+     * Constructor
+     * @param object An instance of Query
+     * @param closure A closure that takes a row and returns an object
+     */
+    public function __construct($query, $hydrator=null)
+    {
+        $this->_query = $query;
+        $this->_hydrator = $hydrator;
+        $this->_resultSet = $query->asyncExecute();
+    }
+
+    /**
+     * Returns the query result set iterator, executing the query if needed
+     */
+    protected function _resultSet()
+    {
+        return $this->_resultSet;
+    }
+}

--- a/lib/Pheasant/Query/Query.php
+++ b/lib/Pheasant/Query/Query.php
@@ -31,6 +31,12 @@ class Query implements \IteratorAggregate, \Countable
         $this->_connection = $connection ?: Pheasant::instance()->connection();
     }
 
+    public function setConnection($connection)
+    {
+        $this->_connection = $connection;
+        return $this;
+    }
+
     /**
      * Sets the SELECT clause, either a single column, an array or varargs.
      * @chainable
@@ -195,6 +201,15 @@ class Query implements \IteratorAggregate, \Countable
     public function execute()
     {
         return $this->_resultset = $this->_connection->execute($this->toSql());
+    }
+
+    /**
+     * Executes the query with the provided connection
+     * @return Result
+     */
+    public function asyncExecute()
+    {
+        return $this->_resultset = $this->_connection->asyncExecute($this->toSql());
     }
 
     /* (non-phpdoc)

--- a/lib/Pheasant/Query/QueryIterator.php
+++ b/lib/Pheasant/Query/QueryIterator.php
@@ -8,10 +8,10 @@ use \Pheasant\Pheasant;
  */
 class QueryIterator implements \SeekableIterator, \Countable
 {
-    private $_query;
-    private $_hydrator;
+    protected $_query;
+    protected $_hydrator;
     private $_iterator;
-    private $_resultSet;
+    protected $_resultSet;
 
     /**
      * Constructor
@@ -39,7 +39,7 @@ class QueryIterator implements \SeekableIterator, \Countable
     /**
      * Returns the query result set iterator, executing the query if needed
      */
-    private function _resultSet()
+    protected function _resultSet()
     {
         if (!isset($this->_resultSet)) {
             $this->_resultSet = $this->_query->execute();

--- a/tests/Pheasant/Tests/CollectionTest.php
+++ b/tests/Pheasant/Tests/CollectionTest.php
@@ -24,6 +24,51 @@ class CollectionTest extends \Pheasant\Tests\MysqlTestCase
         ));
     }
 
+    public function testAsync()
+    {
+        \Pheasant\Database\Mysqli\Connection::$debug = true;
+
+        $dsn = getenv('PHEASANT_TEST_DSN') ?: 'mysql://root@localhost/pheasanttest?charset=utf8';
+        \Pheasant::instance()->connections()
+            ->addConnection('async1', $dsn)
+            ->addConnection('async2', $dsn);
+
+        var_dump('------');
+        ob_flush();
+
+        $c1 = Animal::find('1=1')
+            ->filter('!sleep(1)')
+            ->async('async1')
+            ;
+
+        $c2 = Animal::find('1=1')
+            ->filter('!sleep(2)')
+            ->async('async2')
+            ;
+
+        // Do some stuff in the meantime
+        echo "Count to 3 while queries are running..\n";
+        foreach(range(1,3) as $i) {
+            echo $i."\n";
+            ob_flush();
+            sleep(1);
+        }
+
+        // Should be ready..
+        foreach ($c1 as $a) {
+            echo "1 - $a->name\n";
+            ob_flush();
+        }
+
+        // Still waiting..
+        foreach ($c2 as $a) {
+            echo "2 - $a->name\n";
+            ob_flush();
+        }
+
+        \Pheasant\Database\Mysqli\Connection::$debug = false;
+    }
+
     public function testIteratingEmpty()
     {
         foreach(Animal::find('type=?','mongoose') as $animal) {


### PR DESCRIPTION
Hi Lox,

This is a proof of concept for async queries.

Here's what it looks like in practice:

``` php
// Set up an extra connection to do async stuff on
\Pheasant::instance()->connections()->addConnection('async1', $dsn);

$results = Animal::all()
    ->filter('!sleep(1)') // Pretend this query is slow (sleeps 1 second per row)
    ->async('async1')
    ;

// do some stuff in the meantime..

foreach ($results as $a) // Blocks until results are ready
  var_dump($a->name);
```

Basically, I've added a `async` method to the `Collection` class to kick off a query in the background on a specific connection. It blocks when it needs the result.

The idea would be to have a small pool of connections available for doing queries in the background. It's currently all very explicit so that there's no surprises.

The test case I've included in this pull request demonstrates the feature quite well, it's able to do 3 seconds of work in PHP while two 3sec and 6sec mysql queries run in the background in parallel. the entire test case runs in 6sec rather than 12sec if it were to run sequentially.

Pretty neat huh? :-)
