### PR TITLE
Adding virtual attribute support

### DIFF
--- a/lib/Pheasant/Property.php
+++ b/lib/Pheasant/Property.php
@@ -47,6 +47,15 @@ class Property
     }
 
     /**
+     * Returns a bool for whether the property is virtual
+     * @return bool
+     */
+    public function isVirtual()
+    {
+        return property_exists($this->type->options(), 'virtual');
+    }
+
+    /**
      * Return a closure for accessing the value of the property
      * @return closure
      */

--- a/lib/Pheasant/Schema.php
+++ b/lib/Pheasant/Schema.php
@@ -125,7 +125,7 @@ class Schema
     public function marshal($row)
     {
         foreach($this->_props as $key=>$prop) {
-            if(isset($row[$key])) {
+            if(isset($row[$key]) && !$prop->isVirtual()) {
                 $row[$key] = $prop->type->marshal($row[$key]);
             }
         }


### PR DESCRIPTION
In some cases, it could be useful to have attributes that are not persisted to the DB. For instance, user models could have a virtual `password` property that is bcrypt'ed in a beforeSave handler, and stored in a column called `encrypted_password`.

We are using virtual attribute support together with onHydrate callbacks to normalize our data model as we migrate data to different tables, which allows us to keep model property access consistent, even across data migrations.

These changes allow you to define virtual properties in your schema, which makes sense if you think of the schema as the DomainObject schema, and not the mysql schema. So the property definitions become:

``` php
public funciton properties(){
  'products_id' => new Types\Integer(11, 'primary auto_increment'),
  'products_volume_price' => new Types\Decimal(15, 2),
  # This property is set onHydrate by getting the latest `rate` from the products_rate table
  'rate' => new Types\Decimal(15, 2, 'virtual'),
}
```

If you are interested in this pull, I'll add tests.
