### PR TITLE
Allow magic finders to use underscore columns

### DIFF
--- a/tests/Pheasant/Tests/Examples/UserUnderscore.php
+++ b/tests/Pheasant/Tests/Examples/UserUnderscore.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Pheasant\Tests\Examples;
+
+use \Pheasant\DomainObject;
+use \Pheasant\Types;
+use \Pheasant\Types\Sequence;
+use \Pheasant\Types\String;
+
+class UserUnderscore extends DomainObject
+{
+    public function properties()
+    {
+        return array(
+            'user_id' => new Types\Sequence(),
+            'first_name' => new Types\String(),
+            'last_name' => new Types\String(),
+            );
+    }
+
+    public function relationships()
+    {
+        return array(
+            'UserUnderscorePrefs' => UserPref::hasMany('user_id'),
+            );
+    }
+}
+

--- a/tests/Pheasant/Tests/Examples/UserUnderscorePref.php
+++ b/tests/Pheasant/Tests/Examples/UserUnderscorePref.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Pheasant\Tests\Examples;
+
+use \Pheasant\DomainObject;
+use \Pheasant\Types;
+use \Pheasant\Types\String;
+
+class UserUnderscorePref extends DomainObject
+{
+    public function properties()
+    {
+        return array(
+            'user_id' => new Types\Integer(13, 'primary'),
+            'pref' => new Types\String(),
+            'value' => new Types\String(),
+            );
+    }
+
+    public function relationships()
+    {
+        return array(
+            'User' => UserUnderscore::belongsTo('user_id')
+            );
+    }
+}


### PR DESCRIPTION
We have an existing application that uses underscores in the database column names. The magic finders don't allow this kind of column naming.

This patch is the first of a few that are required for full support of underscore naming conventions.

`::findByProductIdAndOrderId()` will now resolve to `order_id` and `product_id` if it is defined in the schema. Otherwise, it resolves to `orderid` and `productid`.