### PR TITLE
Default string coercion strategy for domain objects

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -491,6 +491,14 @@ class DomainObject implements \ArrayAccess
         return ($this->schema()->hasAttribute($key) && $this->$key !== null);
     }
 
+    /**
+     * String coercion. Returns a value like "ClassName[pkcol1=foo,pkcol2=bar]"
+     */
+    public function __toString()
+    {
+        return $this->className() . (string) $this->identity();
+    }
+
     // ----------------------------------------
     // array object
 

--- a/lib/Pheasant/Identity.php
+++ b/lib/Pheasant/Identity.php
@@ -31,4 +31,18 @@ class Identity implements \IteratorAggregate
     {
         return new Query\Criteria($this->toArray());
     }
+
+    public function __toString()
+    {
+        $array = $this->toArray();
+
+        $keyValues = array_map(
+            function ($k) use ($array) {
+                return sprintf('%s=%s', $k, $array[$k]);
+            },
+            array_keys($array)
+        );
+
+        return sprintf('[%s]', implode(',', $keyValues));
+    }
 }

--- a/tests/Pheasant/Tests/DomainObjectTest.php
+++ b/tests/Pheasant/Tests/DomainObjectTest.php
@@ -192,4 +192,10 @@ class DomainObjectTest extends \Pheasant\Tests\MysqlTestCase
         $animal->load(array('type' => 'frog'));
         $this->assertEquals(array('type'=>'frog'), $animal->changes());
     }
+
+    public function testStringCoercion()
+    {
+        $llama = Animal::create(array('id' => 123));
+        $this->assertEquals('Pheasant\Tests\Examples\Animal[id=123]', (string) $llama);
+    }
 }


### PR DESCRIPTION
Produces a string containing the domain object classname and a stringified version of the object identity.

E.g. per the test case, an `Animal` with `id=1` is stringified to `Animal[id=1]`.
