### PR TITLE
Throw more specific exception when 0 rows found

### DIFF
--- a/lib/Pheasant/Collection.php
+++ b/lib/Pheasant/Collection.php
@@ -38,8 +38,12 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess
         $object = $this->offsetGet(0);
 
         // execute after the query so we save a query
-        if(($count = $this->count()) != 1)
+        $count = $this->count();
+        if ($count === 0) {
+            throw new NotFoundException("Expected 1 element, found 0");
+        } elseif ($count > 1) {
             throw new ConstraintException("Expected only 1 element, found $count");
+        }
 
         return $object;
     }

--- a/lib/Pheasant/NotFoundException.php
+++ b/lib/Pheasant/NotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Pheasant;
+
+/**
+ * Thrown when exactly one item is expected in a Collection but none exist
+ */
+class NotFoundException extends ConstraintException {}

--- a/tests/Pheasant/Tests/CollectionTest.php
+++ b/tests/Pheasant/Tests/CollectionTest.php
@@ -30,7 +30,13 @@ class CollectionTest extends \Pheasant\Tests\MysqlTestCase
         }
     }
 
-    public function testOne()
+    public function testOneWhenZero()
+    {
+        $this->setExpectedException('Pheasant\NotFoundException');
+        $results = Animal::findByName('nonexistent')->one();
+    }
+
+    public function testOneWhenMany()
     {
         $this->setExpectedException('Pheasant\ConstraintException');
         $results = Animal::find()->one();


### PR DESCRIPTION
Rationale: Most applications will want to handle a 0-row result differently from an n-row result from a call to `Collection::one()`.

E.g. a 0-row result might be rethrown as an HTTP 404 error, while an n-row result might indicate a data integrity error (i.e. an HTTP 500 error).

Note: Semantically I don't think `NotFoundException` extends `ConstraintException`, but it's implemented this way for backwards compatibility.

/cc @arthens, @dhotson, @dannymidnight
