### PR TITLE
Support a whitelist in DomainObject::load() to prevent injection attacks

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -423,10 +423,16 @@ class DomainObject implements \ArrayAccess
 
     /**
      * Loads an array of values into the object
+     * @param $filter only processes the keys listed, or false for all
      * @chainable
      */
-    public function load($array)
+    public function load($array, $filter=false)
     {
+        // apply the optional filter
+        if(is_array($filter)) {
+            $array = array_intersect_key($array, array_fill_keys($filter, NULL));
+        }
+
         foreach ($array as $key=>$value) {
             if(is_object($value) || is_array($value))
                 $this->$key = $value;

--- a/tests/Pheasant/Tests/DomainObjectTest.php
+++ b/tests/Pheasant/Tests/DomainObjectTest.php
@@ -19,6 +19,33 @@ class DomainObjectTest extends \Pheasant\Tests\MysqlTestCase
             ;
     }
 
+    public function testLoad()
+    {
+        $animal = new Animal();
+        $animal->load(array(
+            'type' => 'walrus',
+            'name' => 'Frank the Walrus',
+        ));
+
+        $this->assertEquals($animal->type, 'walrus');
+        $this->assertEquals($animal->name, 'Frank the Walrus');
+    }
+
+    public function testFilteredLoad()
+    {
+        $animal = new Animal();
+        $animal->load(array(
+            'type' => 'walrus',
+            'name' => 'Frank the Walrus',
+            'inject' => 'Bobby tables; DROP ALL TABLES'
+        ), array('type', 'name'));
+
+        $this->assertCount(2, $animal->changes());
+        $this->assertEquals($animal->type, 'walrus');
+        $this->assertEquals($animal->name, 'Frank the Walrus');
+        $this->assertFalse(isset($animal->inject));
+    }
+
     public function testDefaultProperties()
     {
         $animal = new Animal();


### PR DESCRIPTION
``` php
<?php

// ensure we only update timeupdated and timelastseen
$user = User::byId($userid)->load($_GET, array('timeupdated', 'timelastseen'))->save();
```
