### PR TITLE
Enumerate instatiable classes only

### DIFF
--- a/lib/Pheasant/Migrate/Enumerator.php
+++ b/lib/Pheasant/Migrate/Enumerator.php
@@ -29,7 +29,8 @@ class Enumerator implements \IteratorAggregate
                 foreach($classes as $class) {
                     $fullClass = empty($namespace) ? "\\$class" : "\\$namespace\\$class";
 
-                    if(is_a($fullClass, "\Pheasant\DomainObject", true)) {
+                    $reflection = new \ReflectionClass($fullClass);
+                    if(is_a($fullClass, "\Pheasant\DomainObject", true) && $reflection->isInstantiable()) {
                         $result []= $fullClass;
                     }
                 }


### PR DESCRIPTION
We typically use the Enumerator for scanning for domain objects to rebuild the db with.

This change modifies it to skip domain objects that can't be instantiated. ie it skips abstract domain object classes.
