### PR TITLE
Quick-fix to bindInto, so filter() and find() handle IN() queries equally

### DIFF
--- a/lib/Pheasant/Database/Binder.php
+++ b/lib/Pheasant/Database/Binder.php
@@ -28,6 +28,10 @@ class Binder
      */
     public function magicBind($sql, array $params=array())
     {
+        if(substr_count($sql, '?') < count($params)) {
+            $params = array($params);
+        }
+
         return $this->_bindInto('\w+\s*(?:!=|=|<>)\s*\?|\?', $sql, $params, function($binder, $param, $token) use ($sql) {
             if ($token == '?') {
                 return $binder->quote($param);

--- a/tests/Pheasant/Tests/BindingTest.php
+++ b/tests/Pheasant/Tests/BindingTest.php
@@ -51,6 +51,24 @@ class BindingTest extends \Pheasant\Tests\MysqlTestCase
             );
     }
 
+    public function testArrayBinding2()
+    {
+        $binder = new Binder();
+        $this->assertEquals(
+            $binder->magicBind('a=?', array(array(1, 2, "llama's"))),
+            "a IN ('1','2','llama\'s')"
+            );
+    }
+
+    public function testArrayBinding3()
+    {
+        $binder = new Binder();
+        $this->assertEquals(
+            $binder->magicBind('a=?', array(1, 2, "llama's")),
+            "a IN ('1','2','llama\'s')"
+            );
+    }
+
     public function testInjectingStatements()
     {
         $binder = new Binder();


### PR DESCRIPTION
Hi Lox,

We've noticed `find()` and `filter()` do not behave equally when given this syntax:

```
\Model\Project::find('status = ?', array('foo', 'bar');
\Model\Project::all()->filter('status = ?', array('foo', 'bar'));
```

The last call (right now) results in a "Parameters left over in bind" exception.

This pull request demonstrates the issue with two test cases and provides a quick/dirty(?) fix.

/cc: @jorisleker
