### PR TITLE
Unmarshal Decimal to float instead of string

### DIFF
--- a/lib/Pheasant/Types/Decimal.php
+++ b/lib/Pheasant/Types/Decimal.php
@@ -26,4 +26,12 @@ class Decimal extends Base
     {
         return $platform->columnSql($column, "decimal({$this->_length},{$this->_scale})", $this->options());
     }
+
+    /* (non-phpdoc)
+     * @see \Pheasant\Type::unmarshal
+     */
+    public function unmarshal($value)
+    {
+        return (float)$value;
+    }
 }

--- a/tests/Pheasant/Tests/TypeMarshallingTest.php
+++ b/tests/Pheasant/Tests/TypeMarshallingTest.php
@@ -19,6 +19,7 @@ class TypeMarshallingTest extends \Pheasant\Tests\MysqlTestCase
                 'id' => new Types\Integer(null, 'primary auto_increment'),
                 'type' => new Types\String(128),
                 'isllama' => new Types\Boolean(array('default'=>true)),
+                'weight' => new Types\Decimal(5, 1),
                 'timecreated' => new Types\DateTime(),
                 'unixtime' => new Types\UnixTimestamp(),
             ));
@@ -37,6 +38,15 @@ class TypeMarshallingTest extends \Pheasant\Tests\MysqlTestCase
         $llamaById = DomainObject::byId(1);
         $this->assertSame($llamaById->id, 1);
         $this->assertSame($llamaById->type, 'Llama');
+    }
+
+    public function testDecimalTypesAreUnmarshalled()
+    {
+        $object = new DomainObject(array('type'=>'Llama', 'weight' => 88.5));
+        $object->save();
+
+        $llamaById = DomainObject::byId(1);
+        $this->assertSame($llamaById->weight, 88.5);
     }
 
     public function testBooleanTypesAreUnmarshalled()


### PR DESCRIPTION
This pull-request fixes an issue where Decimal values would be returned as strings instead of floats. I guess the PR explains itself :-).
## 

PHPUnit 3.7.27 by Sebastian Bergmann.

The Xdebug extension is not loaded. No code coverage will be generated.

...............................................................  63 / 158 ( 39%)
............................................................... 126 / 158 ( 79%)
................................

Time: 2.23 seconds, Memory: 12.25Mb

OK (158 tests, 416 assertions)
