### PR TITLE
Fix to make Collection::order chainable again

### DIFF
--- a/lib/Pheasant/Collection.php
+++ b/lib/Pheasant/Collection.php
@@ -89,7 +89,7 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess
      */
     public function order($sql, $params=array())
     {
-        $this->orderBy($sql, $params);
+        return $this->orderBy($sql, $params);
     }
 
     /**

--- a/tests/Pheasant/Tests/CollectionTest.php
+++ b/tests/Pheasant/Tests/CollectionTest.php
@@ -48,6 +48,13 @@ class CollectionTest extends \Pheasant\Tests\MysqlTestCase
         $this->assertCount(2, $results);
     }
 
+    public function testOrder()
+    {
+        $resultsOrder = Animal::find()->order('type ASC')->toArray();
+        $resultsOrderBy = Animal::find()->orderBy('type ASC')->toArray();
+        $this->assertEquals($resultsOrder, $resultsOrderBy);
+    }
+
     public function testOrderBy()
     {
         $results = Animal::find()->orderBy('type ASC')->toArray();


### PR DESCRIPTION
This is a fix for a regression in 1.2 related to 4d8298180272f59d80941e4c6bc1f698d73ebff4 , which meant `Collection::order()` was no longer chainable.
