### PR TITLE
Testcase for broken (?) Schema::hash()

### DIFF
--- a/tests/Pheasant/Tests/Examples/Project.php
+++ b/tests/Pheasant/Tests/Examples/Project.php
@@ -1,0 +1,15 @@
+<?php
+namespace Pheasant\Tests\Examples;
+
+class Project extends \Pheasant\DomainObject {
+    public function tableName() {
+        return 'projecten';
+    }
+
+    public function properties() {
+        return array(
+            'id' => new \Pheasant\Types\Integer(5, 'primary auto_increment'),
+            'naam' => new \Pheasant\Types\String(255),
+        );
+    }
+}

--- a/tests/Pheasant/Tests/Examples/Veldwerkdag.php
+++ b/tests/Pheasant/Tests/Examples/Veldwerkdag.php
@@ -1,0 +1,23 @@
+<?php
+namespace Pheasant\Tests\Examples;
+
+class Veldwerkdag extends \Pheasant\DomainObject {
+
+    public function tableName() {
+        return 'project_testdata';
+    }
+
+    public function properties() {
+        return array(
+            'id' => new \Pheasant\Types\Integer(11, 'primary auto_increment'),
+            'projectID' => new \Pheasant\Types\Integer(5),
+            'datum' => new \Pheasant\Types\DateTime()
+        );
+    }
+
+    public function relationships() {
+        return array(
+            'Project' => Project::belongsTo('projectID', 'id'),
+        );
+    }
+}

--- a/tests/Pheasant/Tests/IncludesTest.php
+++ b/tests/Pheasant/Tests/IncludesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pheasant\Tests\Relationships;
+
+use \Pheasant\Tests\Examples\Veldwerkdag;
+use \Pheasant\Tests\Examples\Project;
+
+class IncludesTestCase extends \Pheasant\Tests\MysqlTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $migrator = new \Pheasant\Migrate\Migrator();
+        $migrator
+            ->create('project_testdata', Veldwerkdag::schema())
+            ->create('projecten', Project::schema())
+            ;
+
+        $projecten = array(
+            (new Project(array('naam' => 'Foo')))->save(),
+            (new Project(array('naam' => 'Bar')))->save(),
+            (new Project(array('naam' => 'Baz')))->save(),
+            (new Project(array('naam' => 'Moo')))->save(),
+        );
+
+        $veldwerkdagen = array(
+            (new Veldwerkdag(array('datum' => new \DateTime('+1 week'), 'Project' => $projecten[0])))->save(),
+            (new Veldwerkdag(array('datum' => new \DateTime('+2 weeks'), 'Project' => $projecten[2])))->save()
+        );
+
+    }
+
+    public function testBasicIncludes()
+    {
+        $testdays = Veldwerkdag::all()->limit(5)->includes([ 'Project' ]);
+
+        foreach($testdays as $testday) {
+            echo $testday->id."\n";
+            echo $testday->Project->id."\n\n";
+
+            // Please var_dump($schema->hash($object, array($this->local))) in Relationships/BelongsTo.php
+            // to see that the key it is looking for is "Pheasant\Tests\Examples\Project[projectID=1]" while
+            // you expect it to be "Pheasant\Tests\Examples\Project[id=1]"
+        }
+    }
+}


### PR DESCRIPTION
I couldn't reproduce with the Hero/SecretIdentity example DomainObjects, so I've simplified the models which trigger the issue in our project and included them here (PHP 5.4 only, so this testcase might fail on 5.3).

Differences between Hero/SecretIdentity and Veldwerkdag/Project are the definition of the primary key (Sequence vs. Integer) and in the belongsTo relationship we define both local and foreign keys.

Please `var_dump($schema->hash($object, array($this->local)))` in `Relationships/BelongsTo.php` to see the issue. (Not sure how I could let the test fail on this)
