### PR TITLE
Make sure variable can be set to NULL if empty string before

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -429,7 +429,7 @@ class DomainObject implements \ArrayAccess
      */
     public function set($prop, $value)
     {
-        if (!isset($this->_data[$prop]) || $this->_data[$prop] != $value) {
+        if (!isset($this->_data[$prop]) || $this->_data[$prop] !== $value) {
             $this->_data[$prop] = $value;
             $this->_changed[] = $prop;
         }

--- a/tests/Pheasant/Tests/TypeMarshallingTest.php
+++ b/tests/Pheasant/Tests/TypeMarshallingTest.php
@@ -129,4 +129,13 @@ class TypeMarshallingTest extends \Pheasant\Tests\MysqlTestCase
 
         setlocale(LC_ALL, $prevLocale);
     }
+
+    public function testVariableIsNullable() {
+        $object = new DomainObject;
+        $object->weight = 88.5; // var type = double
+        $object->weight = ''; // var type = string
+        $object->weight = null;
+
+        $this->assertSame($object->weight, null);
+    }
 }


### PR DESCRIPTION
I've changed the comparison operator to Identical (===) instead of Equal (==). Also included a testcase.
