### PR TITLE
Prepare for v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+Changes between Pheasant 1.2.1 and 1.3.0
+========================================
+
+  - Support filtering by relationships via `Collection::join()`, per
+    https://github.com/lox/pheasant/pull/96:
+```php
+<?php
+$posts = Post::all()
+    ->join(array('Author' => array('Interests')))
+    ->filter('Interests.key = "Llama Herding"');
+```
+
+  - Support eager-loading related entities via `Collection::includes()`, per
+    https://github.com/lox/pheasant/pull/96:
+```php
+<?php
+// The following snippet generates 3 queries, regardless of the number of posts
+$posts = Post::all()->includes(array('Author'));
+foreach ($posts as $post) {
+    echo $post->Author->fullname;
+}
+```
+
+  - Connections can be overridden on a per-class basis c05883d
+
 Changes between Pheasant 1.2.0 and 1.2.1
 ========================================
 


### PR DESCRIPTION
Is master stable enough for a `v1.3.0` release? Have people tried out `join()`, `includes()`, etc?
/cc @lox
