### PR TITLE
Cache entire object, not just toArray()

### DIFF
--- a/lib/Pheasant/Cache/ArrayCache.php
+++ b/lib/Pheasant/Cache/ArrayCache.php
@@ -26,7 +26,7 @@ class ArrayCache implements \Pheasant\Cache
 
     public function add($object)
     {
-        $this->_cache[(string) $object->identity()] = $object->toArray();
+        $this->_cache[(string) $object->identity()] = $object;
     }
 
     public function clear()

--- a/tests/Pheasant/Tests/ArrayCacheTest.php
+++ b/tests/Pheasant/Tests/ArrayCacheTest.php
@@ -18,6 +18,21 @@ class ArrayCacheTest extends \Pheasant\Tests\MysqlTestCase
             throw new \InvalidArgumentException("Missing animal");
         });
 
-        $this->assertEquals($animal->toArray(), $row);
+        $this->assertEquals($animal, $row);
     }
+
+    public function testMethodIsAccessible()
+    {
+        $cache = new \Pheasant\Cache\ArrayCache();
+        $animal = new Animal(array('id' => 1, 'type' => 'llama'));
+
+        $cache->add($animal);
+
+        $row = $cache->get($animal->identity(), function() {
+            throw new \InvalidArgumentException("Missing animal");
+        });
+
+        $this->assertTrue(method_exists($row, 'scopes'));
+    }
+
 }


### PR DESCRIPTION
Fixes issue #131 