### PR TITLE
Fix empty IN() queries

### DIFF
--- a/lib/Pheasant/Database/Binder.php
+++ b/lib/Pheasant/Database/Binder.php
@@ -108,7 +108,7 @@ class Binder
             $tokens[] = $this->quote($this->escape($a));
         }
 
-        return '('.implode(',', $tokens).')';
+        return $tokens ? '('.implode(',', $tokens).')' : '(null)';
     }
 
     /**

--- a/tests/Pheasant/Tests/BindingTest.php
+++ b/tests/Pheasant/Tests/BindingTest.php
@@ -51,6 +51,15 @@ class BindingTest extends \Pheasant\Tests\MysqlTestCase
             );
     }
 
+    public function testEmptyArrayBinding()
+    {
+        $binder = new Binder();
+        $this->assertEquals(
+            $binder->magicBind('x=?', array(array())),
+            'x IN (null)'
+        );
+    }
+
     public function testInjectingStatements()
     {
         $binder = new Binder();


### PR DESCRIPTION
As reported by @Jud in #107. This PR replaces `IN ()` with `IN (null)` when calling `$binder->magicBind('x = ?', array(array()));`. I've also included a simple test case.