### PR TITLE
[Cleanup] Adding HHVM and PHP7 to travis.yml and allowing them to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: php
 
 php:
+  - hhvm
+  - 7
   - 5.6
   - 5.5
   - 5.4
   - 5.3
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7
 
 before_script:
   - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
Seems like a good thing to show the build status on these platforms. They're allowed to fail, so they won't change the overall project build status.