### PR TITLE
Allow nested relationship includes

### DIFF
--- a/lib/Pheasant/Cache/ArrayCache.php
+++ b/lib/Pheasant/Cache/ArrayCache.php
@@ -26,7 +26,7 @@ class ArrayCache implements \Pheasant\Cache
 
     public function add($object)
     {
-        $this->_cache[(string) $object->identity()] = $object->toArray();
+        $this->_cache[(string) $object->identity()] = $object;
     }
 
     public function clear()

--- a/lib/Pheasant/Collection.php
+++ b/lib/Pheasant/Collection.php
@@ -310,7 +310,7 @@ class Collection implements \IteratorAggregate, \Countable, \ArrayAccess
     {
         foreach (Relationship::normalizeMap($rels) as $alias=>$nested) {
             $this->_includes[$alias] = new Relationships\Includer(
-                $this->_query, $this->_schema->relationship($alias)
+                $this->_query, $this->_schema->relationship($alias), $nested
             );
         }
 

--- a/lib/Pheasant/Relationships/BelongsTo.php
+++ b/lib/Pheasant/Relationships/BelongsTo.php
@@ -33,7 +33,7 @@ class BelongsTo extends Relationship
             $schema = \Pheasant::instance()->schema($this->class);
 
             if ($cached = $cache->get($schema->hash($object, array(array($this->local, $this->foreign))))) {
-                return $schema->hydrate($cached);
+                return $cached;
             }
         }
 

--- a/lib/Pheasant/Relationships/HasOne.php
+++ b/lib/Pheasant/Relationships/HasOne.php
@@ -34,7 +34,7 @@ class HasOne extends Relationship
         if ($cache) {
             $schema = \Pheasant::instance()->schema($this->class);
             if ($cached = $cache->get($schema->hash($object, array(array($this->local, $this->foreign))))) {
-                return $schema->hydrate($cached)->useCache($cache);
+                return $cached;
             }
         }
 

--- a/lib/Pheasant/Relationships/Includer.php
+++ b/lib/Pheasant/Relationships/Includer.php
@@ -15,13 +15,15 @@ class Includer
     private
         $_query,
         $_rel,
+        $_nested,
         $_cache
         ;
 
-    public function __construct($query, $rel)
+    public function __construct($query, $rel, $nested=array())
     {
         $this->_query = $query;
         $this->_rel = $rel;
+        $this->_nested = $nested;
     }
 
     public function loadCache()
@@ -35,7 +37,8 @@ class Includer
             ->finderFor($this->_rel->class)
             ->find($this->_rel->class, new Criteria(
                 $this->_rel->foreign.'=?', array($ids))
-            );
+            )
+            ->includes($this->_nested);
 
         foreach ($relatedObjects as $obj) {
             $this->_cache->add($obj);

--- a/tests/Pheasant/Tests/ArrayCacheTest.php
+++ b/tests/Pheasant/Tests/ArrayCacheTest.php
@@ -18,6 +18,6 @@ class ArrayCacheTest extends \Pheasant\Tests\MysqlTestCase
             throw new \InvalidArgumentException("Missing animal");
         });
 
-        $this->assertEquals($animal->toArray(), $row);
+        $this->assertEquals($animal, $row);
     }
 }


### PR DESCRIPTION
This fixes #130 and #131 and cleans up some errors that would occur (`Undefined method "useCache"`) when using `include`.

You can include multiple relationships like:
```php
Power::all()->includes(['Hero' => ['SecretIdentity']]);
```