### PR TITLE
Add support for the native JSON column type as introduced in MySQL 5.7

### DIFF
--- a/lib/Pheasant/Types/JsonType.php
+++ b/lib/Pheasant/Types/JsonType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pheasant\Types;
+
+use Pheasant\Exception;
+
+/**
+ * A JSON type
+ * @see https://dev.mysql.com/doc/refman/5.7/en/json.html
+ */
+class JsonType extends BaseType
+{
+    /* (non-phpdoc)
+     * @see \Pheasant\Type::columnSql
+     */
+    public function columnSql($column, $platform)
+    {
+        return $platform->columnSql($column, 'json', $this->options());
+    }
+
+    /* (non-phpdoc)
+     * @see \Pheasant\Type::unmarshal
+     */
+    public function unmarshal($value)
+    {
+        $value = json_decode($value);
+        
+        if (json_last_error()) {
+            throw new Exception('Could not unmarshal json: ' . json_last_error_msg());
+        }
+        
+        return $value;
+    }
+
+    /* (non-phpdoc)
+     * @see \Pheasant\Type::marshal
+     */
+    public function marshal($value)
+    {
+        $value = json_encode($value);
+        
+        if (json_last_error()) {
+            throw new Exception('Could not marshal json: ' . json_last_error_msg());
+        }
+        
+        return $value;
+    }
+}

--- a/tests/Pheasant/Tests/DomainObjectTest.php
+++ b/tests/Pheasant/Tests/DomainObjectTest.php
@@ -54,7 +54,7 @@ class DomainObjectTest extends \Pheasant\Tests\MysqlTestCase
         $animal = new Animal();
         $this->assertEquals($animal->type, 'llama');
         $this->assertEquals($animal->toArray(),
-            array('id'=>NULL, 'type'=>'llama', 'name'=>null));
+            array('id' => NULL, 'type' => 'llama', 'name' => null, 'meta' => null));
 
         $llama = new Animal(array('type'=>'llama'));
         $frog = new Animal(Array('type'=>'frog'));

--- a/tests/Pheasant/Tests/Examples/Animal.php
+++ b/tests/Pheasant/Tests/Examples/Animal.php
@@ -18,6 +18,7 @@ class Animal extends DomainObject
                 'id' => new Types\IntegerType(11, 'primary auto_increment'),
                 'type' => new Types\StringType(255, 'required default=llama'),
                 'name' => new Types\StringType(255),
+                'meta' => new Types\JsonType(),
             ));
     }
 

--- a/tests/Pheasant/Tests/TypeMarshallingTest.php
+++ b/tests/Pheasant/Tests/TypeMarshallingTest.php
@@ -130,12 +130,26 @@ class TypeMarshallingTest extends \Pheasant\Tests\MysqlTestCase
         setlocale(LC_ALL, $prevLocale);
     }
 
-    public function testVariableIsNullable() {
+    public function testVariableIsNullable()
+    {
         $object = new DomainObject;
         $object->weight = 88.5; // var type = double
         $object->weight = ''; // var type = string
         $object->weight = null;
 
         $this->assertSame($object->weight, null);
+    }
+    
+    public function testJsonTypesAreUnmarshalled()
+    {
+        $object = new Animal(array(
+            'type' => 'Llama', 
+            'meta' => array('foo' => 'bar')
+        ));
+        $object->save();
+        
+        $llamaById = Animal::byId(1);
+        $this->assertInstanceOf('stdClass', $llamaById->meta);
+        $this->assertSame($llamaById->meta->foo, 'bar');
     }
 }

--- a/tests/Pheasant/Tests/TypesTest.php
+++ b/tests/Pheasant/Tests/TypesTest.php
@@ -107,4 +107,10 @@ class TypesTest extends \Pheasant\Tests\MysqlTestCase
     {
         $this->assertEquals($type->columnSql('test', new \Pheasant\Database\MysqlPlatform()), $sql);
     }
+    
+    public function testJson()
+    {
+        $type = new Types\JsonType();
+        $this->assertMysqlColumnSql('`test` json', $type);
+    }
 }


### PR DESCRIPTION
> "As of MySQL 5.7.8, MySQL supports a native JSON data type that enables efficient access to data in JSON (JavaScript Object Notation) documents."
# https://dev.mysql.com/doc/refman/5.7/en/json.html

This adds support for (un)mashalling JSON column types. Required >5.7.8 to run properly.