### PR TITLE
Using magic __set in load()

### DIFF
--- a/lib/Pheasant/DomainObject.php
+++ b/lib/Pheasant/DomainObject.php
@@ -469,7 +469,7 @@ class DomainObject implements \ArrayAccess
             if(is_object($value) || is_array($value))
                 $this->$key = $value;
             else
-                $this->set($key, $value);
+                $this->__set($key, $value);
         }
 
         return $this;


### PR DESCRIPTION
to prevent loading keys that do not match schema
fix for #164 